### PR TITLE
implemented transactions using the entity manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6985,7 +6985,7 @@
     "thenify-all": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }


### PR DESCRIPTION
- This Pull request addresses the issue of using database transactions in certain cases e.g
- When making peer to peer transfers between users, in order to avoid integrity issues from either party, i.e a user facilitates a peer transfer to another user but somehow an error occurs midway and the sender is debited but the receiver doesn't receive the fund. This approach avoids that by keeping our transactions atomic